### PR TITLE
Trigger build-artifacts by git tag

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -43,10 +43,10 @@ jobs:
           cd assets/
           pipenv sync
           git lfs install
-    - name: Set target branch if ref is not tagged
-      if: !startsWith(github.ref, 'refs/tags/')
+    - name: Set target branch if ref is tagged
+      if: startsWith(github.ref, 'refs/tags/')
       run: |
-        echo DEPLOY_BRANCH=stubs_pre >> $GITHUB_ENV
+        echo DEPLOY_BRANCH=stubs >> $GITHUB_ENV
     - name: Build and push artifacts
       if: github.ref == env.MASTER_BRANCH
       env:
@@ -61,7 +61,7 @@ jobs:
           cd assets/
           pipenv run python publish_artifacts.py \
             --url git@github.com:rospypi/simple.git \
-            --branch ${DEPLOY_BRANCH} --ref-branch stubs --push
+            --branch ${DEPLOY_BRANCH:-stubs_pre} --ref-branch stubs --push
     - name: Build artifacts
       if: github.ref != env.MASTER_BRANCH
       run: |


### PR DESCRIPTION
I updated build-artifacts to

- be triggered by git tag
- update workflow to push artifacts into `stubs` and `stubs_pre` when it is triggered by a tag and a branch push, respectively