### PR TITLE
Use not _ but - for a package directory name

### DIFF
--- a/buildtool/buildtool/artifacts.py
+++ b/buildtool/buildtool/artifacts.py
@@ -10,6 +10,10 @@ SDIST_NAME_TEMPLATE = "{package_name}-{version}.tar.gz"
 SDIST_EXTENSION = ".tar.gz"
 
 
+def to_package_dir_name(name: str) -> str:
+    return name.replace("_", "-")
+
+
 def get_universal_wheel_name(package_name: str, version: str) -> str:
     return WHEEL_NAME_TEMPLATE.format(
         package_name=package_name.replace("-", "_"),
@@ -24,7 +28,7 @@ def get_universal_wheel_path(
 ) -> pathlib.Path:
     return (
         artifacts_dir
-        / package_name
+        / to_package_dir_name(package_name)
         / get_universal_wheel_name(package_name, version.version)
     )
 
@@ -41,7 +45,11 @@ def get_sdist_path(
     package_name: str,
     version: Version,
 ) -> pathlib.Path:
-    return artifacts_dir / package_name / get_sdist_name(package_name, version.version)
+    return (
+        artifacts_dir
+        / to_package_dir_name(package_name)
+        / get_sdist_name(package_name, version.version)
+    )
 
 
 def extract_version(sdist_path: str) -> str:

--- a/buildtool/buildtool/artifacts.py
+++ b/buildtool/buildtool/artifacts.py
@@ -10,8 +10,12 @@ SDIST_NAME_TEMPLATE = "{package_name}-{version}.tar.gz"
 SDIST_EXTENSION = ".tar.gz"
 
 
-def to_package_dir_name(name: str) -> str:
+def _to_package_dir_name(name: str) -> str:
     return name.replace("_", "-")
+
+
+def get_package_dir(artifacts_dir: pathlib.Path, package_name: str) -> pathlib.Path:
+    return artifacts_dir / _to_package_dir_name(package_name)
 
 
 def get_universal_wheel_name(package_name: str, version: str) -> str:
@@ -26,10 +30,8 @@ def get_universal_wheel_path(
     package_name: str,
     version: Version,
 ) -> pathlib.Path:
-    return (
-        artifacts_dir
-        / to_package_dir_name(package_name)
-        / get_universal_wheel_name(package_name, version.version)
+    return get_package_dir(artifacts_dir, package_name) / get_universal_wheel_name(
+        package_name, version.version
     )
 
 
@@ -45,10 +47,8 @@ def get_sdist_path(
     package_name: str,
     version: Version,
 ) -> pathlib.Path:
-    return (
-        artifacts_dir
-        / to_package_dir_name(package_name)
-        / get_sdist_name(package_name, version.version)
+    return get_package_dir(artifacts_dir, package_name) / get_sdist_name(
+        package_name, version.version
     )
 
 
@@ -75,7 +75,7 @@ def find_latest_version(
     package_name: str,
     version_class: Type[TVersion],
 ) -> Optional[TVersion]:
-    package_dir = artifacts_dir / package_name
+    package_dir = get_package_dir(artifacts_dir, package_name)
     if not package_dir.exists():
         return None
 

--- a/buildtool/buildtool/builder.py
+++ b/buildtool/buildtool/builder.py
@@ -5,7 +5,12 @@ import pathlib
 import shutil
 from typing import List, Optional, Tuple
 
-from .artifacts import find_latest_version, get_next_available_version, get_sdist_path
+from .artifacts import (
+    find_latest_version,
+    get_next_available_version,
+    get_sdist_path,
+    to_package_dir_name,
+)
 from .context import BuilderContext
 from .package_hash import get_package_hashes, has_same_package_hashes
 from .packaging import create_artifacts
@@ -53,7 +58,7 @@ def _build_package(
             package_name,
             release_version,
         )
-        package_dir = artifacts_dir / package_name
+        package_dir = artifacts_dir / to_package_dir_name(package_name)
         package_dir.mkdir(parents=True, exist_ok=True)
         shutil.copy2(artifacts.sdist_path, package_dir)
         shutil.copy2(artifacts.bdist_path, package_dir)

--- a/buildtool/buildtool/builder.py
+++ b/buildtool/buildtool/builder.py
@@ -8,8 +8,8 @@ from typing import List, Optional, Tuple
 from .artifacts import (
     find_latest_version,
     get_next_available_version,
+    get_package_dir,
     get_sdist_path,
-    to_package_dir_name,
 )
 from .context import BuilderContext
 from .package_hash import get_package_hashes, has_same_package_hashes
@@ -58,7 +58,7 @@ def _build_package(
             package_name,
             release_version,
         )
-        package_dir = artifacts_dir / to_package_dir_name(package_name)
+        package_dir = get_package_dir(artifacts_dir, package_name)
         package_dir.mkdir(parents=True, exist_ok=True)
         shutil.copy2(artifacts.sdist_path, package_dir)
         shutil.copy2(artifacts.bdist_path, package_dir)


### PR DESCRIPTION
In order to mark a package as the stub for library A, the name of the package should be the same as `A-stubs` while pip automatically replaces `_` to `-` in [its packaging](https://github.com/pypa/pip/blob/0bb3ac87f5bb149bd75cceac000844128b574385/src/pip/_internal/models/wheel.py#L33), and also in [pip install](https://github.com/pypa/pip/blob/0bb3ac87f5bb149bd75cceac000844128b574385/src/pip/_internal/index/package_finder.py#L176-L183).

But according to PEP 503, the project name for a URL `/<project>/<binary>` should be a normalized name.
https://www.python.org/dev/peps/pep-0503/#normalized-names

Therefore, I replaced the builder logic to
- Use the normalized name for a package directory
- Use the name as is for a package name