### PR TITLE
Rename update-pages to build-pages

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -68,8 +68,8 @@ jobs:
       run: |
           cd assets/
           pipenv run python publish_artifacts.py
-  update-pages:
-    name: Update gh_pages for rospypi/simple
+  build-pages:
+    name: Build gh_pages
     needs: build-stubs
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
The current action name `Update gh_pages` sounds like the action is going to push gh-pages in rospypi/simple.
To avoid confusion, I renamed the task to just `Build gh-pages`.