### PR TITLE
Install genmypy from vcs

### DIFF
--- a/assets/Pipfile
+++ b/assets/Pipfile
@@ -17,6 +17,7 @@ GitPython = {version = ">=3.1.0,<4.0.0"}
 buildtool = {path = "../buildtool/", editable = true}
 genmsg = {version = "==0.5.12", index = "rospypi"}
 genpy = {version = "==0.6.14", index = "rospypi"}
+genmypy = {git = "https://github.com/rospypi/genmypy.git", ref = "a3eb9ae626397185034b28b562521b50e2fb836e"}
 
 [requires]
 python_version = "3.8"

--- a/assets/Pipfile.lock
+++ b/assets/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "6bc6a4503ede36868d82471888670e531dd7ad6da0039225432661058d8f8262"
+            "sha256": "0b83eb0773499449a9ef2eaf16da2f2c0b54a26588297747187c037c31bb7af5"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -41,6 +41,10 @@
             "index": "rospypi",
             "version": "==0.5.12"
         },
+        "genmypy": {
+            "git": "https://github.com/rospypi/genmypy.git",
+            "ref": "a3eb9ae626397185034b28b562521b50e2fb836e"
+        },
         "genpy": {
             "hashes": [
                 "sha256:8ee07093f922cecdd618168264d52010bd7e09f39d570a78a4399ac1101d7b09",
@@ -48,13 +52,6 @@
             ],
             "index": "rospypi",
             "version": "==0.6.14"
-        },
-        "genpyi": {
-            "hashes": [
-                "sha256:465f7dd8c9d976427e01bfc627782bbf797cea8d5b62036018ddfa2e3db11768",
-                "sha256:5243e40170a3d734680f0f1af991cdd354a64a405102f18b10796af81fb57cc8"
-            ],
-            "version": "==0.1.0"
         },
         "gitdb": {
             "hashes": [
@@ -120,7 +117,7 @@
                 "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1",
                 "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'",
             "version": "==2.4.7"
         },
         "pyyaml": {
@@ -171,16 +168,16 @@
                 "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b",
                 "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'",
             "version": "==0.10.2"
         },
         "typing-extensions": {
             "hashes": [
-                "sha256:7cb407020f00f7bfc3cb3e7881628838e69d8f3fcab2f64742a5e76b2f841918",
-                "sha256:99d4073b617d30288f569d3f13d2bd7548c3a7e4c8de87db09a9d29bb3a4a60c",
-                "sha256:dafc7639cde7f1b6e1acc0f457842a83e722ccca8eef5270af2d74792619a89f"
+                "sha256:0ac0f89795dd19de6b97debb0c6af1c70987fd80a2d62d1958f7e56fcc31b497",
+                "sha256:50b6f157849174217d0656f99dc82fe932884fb250826c18350e159ec6cdf342",
+                "sha256:779383f6086d90c99ae41cf0ff39aac8a7937a9283ce0a414e5dd782f4c94a84"
             ],
-            "version": "==3.7.4.3"
+            "version": "==3.10.0.0"
         }
     },
     "develop": {
@@ -193,11 +190,11 @@
         },
         "attrs": {
             "hashes": [
-                "sha256:31b2eced602aa8423c2aea9c76a724617ed67cf9513173fd3a4f03e3a929c7e6",
-                "sha256:832aa3cde19744e49938b91fea06d69ecb9e649c93ba974535d08ad92164f700"
+                "sha256:149e90d6d8ac20db7a955ad60cf0e6881a3f20d37096140088356da6c716b0b1",
+                "sha256:ef6aaac3ca6cd92904cdd0d83f629a15f18053ec84e6432106f7a4d04ae4f5fb"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==20.3.0"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==21.2.0"
         },
         "black": {
             "hashes": [
@@ -357,7 +354,7 @@
                 "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1",
                 "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'",
             "version": "==2.4.7"
         },
         "pysen": {
@@ -373,11 +370,11 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:671238a46e4df0f3498d1c3270e5deb9b32d25134c99b7d75370a68cfbe9b634",
-                "sha256:6ad9c7bdf517a808242b998ac20063c41532a570d088d77eec1ee12b0b5574bc"
+                "sha256:50bcad0a0b9c5a72c8e4e7c9855a3ad496ca6a881a3641b4260605450772c54b",
+                "sha256:91ef2131a9bd6be8f76f1f08eac5c5317221d6ad1e143ae03894b862e8976890"
             ],
             "index": "pypi",
-            "version": "==6.2.3"
+            "version": "==6.2.4"
         },
         "regex": {
             "hashes": [
@@ -438,7 +435,7 @@
                 "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b",
                 "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'",
             "version": "==0.10.2"
         },
         "tomlkit": {
@@ -486,11 +483,11 @@
         },
         "typing-extensions": {
             "hashes": [
-                "sha256:7cb407020f00f7bfc3cb3e7881628838e69d8f3fcab2f64742a5e76b2f841918",
-                "sha256:99d4073b617d30288f569d3f13d2bd7548c3a7e4c8de87db09a9d29bb3a4a60c",
-                "sha256:dafc7639cde7f1b6e1acc0f457842a83e722ccca8eef5270af2d74792619a89f"
+                "sha256:0ac0f89795dd19de6b97debb0c6af1c70987fd80a2d62d1958f7e56fcc31b497",
+                "sha256:50b6f157849174217d0656f99dc82fe932884fb250826c18350e159ec6cdf342",
+                "sha256:779383f6086d90c99ae41cf0ff39aac8a7937a9283ce0a414e5dd782f4c94a84"
             ],
-            "version": "==3.7.4.3"
+            "version": "==3.10.0.0"
         },
         "unidiff": {
             "hashes": [

--- a/buildtool/buildtool/stub_build.py
+++ b/buildtool/buildtool/stub_build.py
@@ -1,7 +1,7 @@
 import pathlib
 from typing import Any, Callable, Dict, List, Literal, Optional, Union
 
-import genpyi.cli
+import genmypy.cli
 from pydantic import PrivateAttr
 
 from .build_action import BuildAction
@@ -51,17 +51,17 @@ class StubBuild(BuildAction):
         include_paths = self.get_formatted_include_paths(package_dir, context)
 
         self._stubgen_impl(target_package, source_files, str(out_dir), include_paths)
-        genpyi.cli.run_module(str(source_dir), str(out_dir), "genmsg")
+        genmypy.cli.run_module(str(source_dir), str(out_dir), "genmsg")
 
 
 class MessageStubBuild(StubBuild):
     type: Literal["msg_stub_gen"]
     _source_extension = PrivateAttr(".msg")
-    _stubgen_impl = PrivateAttr(genpyi.cli.run_message)
+    _stubgen_impl = PrivateAttr(genmypy.cli.run_message)
 
 
 class ServiceStubBuild(StubBuild):
     type: Literal["srv_stub_gen"]
 
     _source_extension = PrivateAttr(".srv")
-    _stubgen_impl = PrivateAttr(genpyi.cli.run_service)
+    _stubgen_impl = PrivateAttr(genmypy.cli.run_service)

--- a/buildtool/setup.py
+++ b/buildtool/setup.py
@@ -10,7 +10,7 @@ setup(
     install_requires=[
         "PyYAML>=5.4,<6.0",
         "build>=0.3.0,<0.4.0",
-        "genpyi>=0.1.0,<0.2.0",
+        "genmypy>=0.3.0,<0.4.0",
         "pydantic>=1.8.0,<2.0.0",
     ],
     package_data={"buildtool": ["py.typed"]},


### PR DESCRIPTION
I updated this repository to install genmypy from VCS directly.
Here are the pros & cons:

## Use only released version (current)
### Pros
- Easy to know which version ros_stubs uses
- (We should make a release as soon as we have a new feature)
### Cons
- We cannot test genmypy in ros_stubs without making a release

## Use VSC, untagged/unreleased versions (this PR)
### Pros
- We can test genmypy in ros_stubs before making a release
### Cons
- Hard to tell whether the hash of genmypy is in the master branch and whether the version is up-to-date at a glance

----

Also, there are several ways to install it from VCS:
1. Add a `git` entry in `Pipfile` to install `genmypy` + `setup.py` just requires `genmypy` to be installed (This PR)
2. Add `genmypy` as a submodule + Add a `path` entry in `Pipfile` + `setup.py` just requires `genmypy` to be installed
3. Add a `git+https://github.com/...` entry in `install_requires` section of `setup.py`

I considered all of them and found 1. is the simplest way to allow developers to install an arbitrary version of genmypy without modifying any files in their local environment, i.e. developer can try a different version of genmypy by just running `pip install` after `pipenv sync`. Hence I chose 1. in this PR.