### PR TITLE
Export more components in rospy.__init__

### DIFF
--- a/src/rospy-stubs/__init__.pyi
+++ b/src/rospy-stubs/__init__.pyi
@@ -1,3 +1,5 @@
+from std_msgs.msg import Header as Header  # NOQA
+
 from .client import DEBUG as DEBUG  # NOQA
 from .client import ERROR as ERROR  # NOQA
 from .client import FATAL as FATAL  # NOQA
@@ -55,6 +57,7 @@ from .rostime import get_rostime as get_rostime  # NOQA
 from .rostime import get_time as get_time  # NOQA
 from .service import ServiceException as ServiceException  # NOQA
 from .timer import Rate as Rate  # NOQA
+from .timer import Timer as Timer  # NOQA
 from .timer import sleep as sleep  # NOQA
 from .topics import Message as Message  # NOQA
 from .topics import Publisher as Publisher  # NOQA


### PR DESCRIPTION
I added some missing items in `rospy.__init__` in order to align with the original library.
See the following link for the original source code:

https://github.com/ros/ros_comm/blob/f5fa3a168760d62e9693f10dcb9adfffc6132d22/clients/rospy/src/rospy/__init__.py

For example, `rospy.Time` would be an error with the current stub.