### PR TITLE
Remove _TCallbackArgs from Subscriber

### DIFF
--- a/src/rospy-stubs/topics.pyi
+++ b/src/rospy-stubs/topics.pyi
@@ -81,12 +81,12 @@ class _TopicImpl(Generic[_TMessage]):
     def get_stats_info(self) -> List[Tuple[str, str, str, str, str, bool, str]]: ...
     def get_stats(self) -> Any: ...
 
-class Subscriber(Topic[_TMessage, _TCallbackArgs]):
+class Subscriber(Topic[_TMessage]):
     callback: Callable[..., None] = ...
-    callback_args: _TCallbackArgs = ...
+    callback_args: Any = ...
     @overload
     def __init__(
-        self: "Subscriber[_TMessage, _TCallbackArgs]",
+        self,
         name: str,
         data_class: Type[_TMessage],
         callback: Optional[Callable[[_TMessage, _TCallbackArgs], None]] = ...,
@@ -97,7 +97,7 @@ class Subscriber(Topic[_TMessage, _TCallbackArgs]):
     ) -> None: ...
     @overload
     def __init__(
-        self: "Subscriber[_TMessage, None]",
+        self,
         name: str,
         data_class: Type[_TMessage],
         callback: Optional[Callable[[_TMessage], None]] = ...,


### PR DESCRIPTION
Originally, I though it is better to include `_TCallbackArgs` in the generics of `Subscriber` for the better type annotation experience.
The advantage for include `_TCallbackArgs` in type signature is we can verify the assignment for `callback_args`, i.e. we can detect the following type error:
```py
foo = Subscriber(..., callback_args=1)
foo.callback_args = "foo"  # error
```

But later, I found that this would also increase efforts to annotate the optional subscribers:
```py
foo: Optional[Subscriber[Message, None]] = None
foo = ...  # lazy initialization
```
and the annotation for `_TCallbackArgs` of `Subscriber` would be `None` in most of my cases.

Unfortunately, mypy and typing module don't have a default argument for the `Generic` parameter.

As such, I would like to remove `_TCallbackArgs` from the class signature so that we can write:
```py
foo: Optional[Subscriber[Message]] = None
foo = ...  # lazy initialization
```

I will keep `_TCallbackArgs` in `__init__` since we can validate whether `callback` argument takes `_TCallbackArgs` in the second argument or not without any extra effort.